### PR TITLE
Feat: HORA ENTREGA QUE SEA RANGO

### DIFF
--- a/src/entities/IPedido.ts
+++ b/src/entities/IPedido.ts
@@ -9,6 +9,7 @@ export interface IPedido {
 
   fecha_pedido: Date;
   hora_entrega_acordada: Date;
+  hora_entrega_rango_final: Date;
   hora_entrega_real: Date;
 
   observaciones: string;

--- a/src/entities/implements/PedidoSchema.ts
+++ b/src/entities/implements/PedidoSchema.ts
@@ -26,6 +26,10 @@ const PedidoSchema = new Schema({
     type: Date,
     default: Date.now
   },
+  hora_entrega_rango_final: {
+    type: Date,
+    required: false,
+  },
   observaciones: {
     type: String,
     default: ""

--- a/src/services/shipping.service.ts
+++ b/src/services/shipping.service.ts
@@ -172,6 +172,12 @@ const updateShipping = async (newData: any, shippingId: string) => {
       .format("YYYY-MM-DD HH:mm:ss");
   }
 
+  if (newData.hora_entrega_rango_final) {
+    newData.hora_entrega_rango_final = moment
+      .tz(newData.hora_entrega_rango_final, "America/La_Paz")
+      .format("YYYY-MM-DD HH:mm:ss");
+  }
+
   if (!newData.hora_entrega_real && newData.hora_entrega_acordada) {
     newData.hora_entrega_real = newData.hora_entrega_acordada;
   }


### PR DESCRIPTION
# Cambios realizados
Tanto en las entidades como en los esquemas de Mongoose se agregó el campo `hora_entrega_rango_final` para almacenar el dato propuesto por la tarea. 

La lógica de guardado de este dato se maneja del mismo modo que se manejan otros campos que guardan horas, esto para evitar problemas posteriores:
```ts
if (newData.hora_entrega_rango_final) {
    newData.hora_entrega_rango_final = moment
      .tz(newData.hora_entrega_rango_final, "America/La_Paz")
      .format("YYYY-MM-DD HH:mm:ss");
  }
```